### PR TITLE
Only consider stages containing 'prod' as protected

### DIFF
--- a/src/serverless-stage-destroyer.ts
+++ b/src/serverless-stage-destroyer.ts
@@ -93,7 +93,7 @@ export class ServerlessStageDestroyer {
 
     private checkForProtectedStage(stage: string) {
       // Another safeguard against destroying protected stages
-      if (stage == "master" || stage == "main" || stage == "staging" || stage == "production") {
+      if (stage.toLowerCase().includes("prod")) {
         throw `
           **********************************************************************
           You've requested a destroy for a protected stage (${stage}).


### PR DESCRIPTION
## Purpose

This changeset changes what's considered a protected stage; any stage containing the substring 'prod' will be refused if a delete is attempted with this plugin.

#### Linked Issues to Close

N/A

## Approach

Any stage name, converted to lowercase, that contains 'prod' will not be allowed to use this plugin.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [ ] Any associated issue(s) are linked above.
- [ ] This PR and linked issues(s) are a complete description of the changeset.
- [ ] Someone has been assigned this PR.
- [ ] Someone has been marked as reviewer on this PR.

#### Pull Request Assignee Checklist

- [ ] Any associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for any linked issues.
- [ ] This PR and linked issues(s) are a complete description of the changeset.
