### PR TITLE
Refactor to accept named options and add wait option

### DIFF
--- a/src/serverless-stage-destroyer.ts
+++ b/src/serverless-stage-destroyer.ts
@@ -26,13 +26,15 @@ export class ServerlessStageDestroyer {
   public async destroy(
     region: string,
     stage: string,
-    props: {
+    options: {
       filters: Tag[];
       verify: boolean;
+      wait: boolean;
     }
   ) {
-    const filters = props.filters || [];
-    const verify = props.verify !== false;
+    const filters = options.filters || [];
+    const verify = options.verify !== false;
+    const wait = options.wait !== false;
     // First, check if a protected stage name has been passed, and fail if so.
     this.checkForProtectedStage(stage);
 
@@ -63,8 +65,10 @@ export class ServerlessStageDestroyer {
     }
 
     // Fifth, wait for stacks to be deleted.
-    for (let i of stacksToDestroy || []) {
-      await this.ensureStackIsDeleted(region, `${i.StackName}`);
+    if (wait) {
+      for (let i of stacksToDestroy || []) {
+        await this.ensureStackIsDeleted(region, `${i.StackName}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Purpose

This changeset is a breaking change, and the package now accepts a map of options.

#### Linked Issues to Close

Closes #4
Closes #10 

## Approach

The destroyer function now expects a stage string, a region string, and an object that may contain filters (like PROJECT), a boolean to verify or not, and a boolean to wait for destruction to be complete.

Tests were added for the wait option

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] Any associated issue(s) are linked above.
- [x] This PR and linked issues(s) are a complete description of the changeset.
- [x] Someone has been assigned this PR.
- [x] Someone has been marked as reviewer on this PR.

#### Pull Request Assignee Checklist

- [ ] Any associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for any linked issues.
- [ ] This PR and linked issues(s) are a complete description of the changeset.
