### PR TITLE
Update destroyStack to start by deleting the stack's ENIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.128.0",
+        "@aws-sdk/client-ec2": "^3.238.0",
         "@aws-sdk/client-s3": "^3.128.0",
         "@types/readline-sync": "^1.4.4",
         "readline-sync": "^1.4.10"
@@ -198,6 +199,56 @@
         "@aws-sdk/middleware-logger": "3.226.0",
         "@aws-sdk/middleware-recursion-detection": "3.226.0",
         "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.226.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.238.0.tgz",
+      "integrity": "sha512-M/5t1hMKTRtM94fPVXqPf2zJ5DowN/c/82YpsAmeTZjWXZdcQu9TIvCTd3A0VkKBMI2lY0+w/8KxjNiOOC7jTw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.238.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.238.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.226.0",
         "@aws-sdk/middleware-serde": "3.226.0",
         "@aws-sdk/middleware-signing": "3.226.0",
         "@aws-sdk/middleware-stack": "3.226.0",
@@ -1052,6 +1103,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.226.0.tgz",
+      "integrity": "sha512-1ZXmNO5Gs/7p2KA8HYcIgcehEvzo7l4y2wtwIEOdkeT9rARwNm3IfjphrhzEY9Rl4GVbgEVaLr+RldngC8vDKw==",
+      "dependencies": {
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-format-url": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
@@ -1432,6 +1499,19 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
       "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
       "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.226.0.tgz",
+      "integrity": "sha512-IhuA8iuJL1urWqZZmVzW79mHnwFEEP6rMsSKgAfMmuzowhtgk9p/sT2OVPkXk0LeZL2Ghsnw1W2JfPIs8x1qVg==",
+      "dependencies": {
+        "@aws-sdk/querystring-builder": "3.226.0",
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
@@ -11913,6 +11993,53 @@
         "uuid": "^8.3.2"
       }
     },
+    "@aws-sdk/client-ec2": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.238.0.tgz",
+      "integrity": "sha512-M/5t1hMKTRtM94fPVXqPf2zJ5DowN/c/82YpsAmeTZjWXZdcQu9TIvCTd3A0VkKBMI2lY0+w/8KxjNiOOC7jTw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.238.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.238.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.226.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
     "@aws-sdk/client-s3": {
       "version": "3.234.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.234.0.tgz",
@@ -12628,6 +12755,19 @@
         "uuid": "^8.3.2"
       }
     },
+    "@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.226.0.tgz",
+      "integrity": "sha512-1ZXmNO5Gs/7p2KA8HYcIgcehEvzo7l4y2wtwIEOdkeT9rARwNm3IfjphrhzEY9Rl4GVbgEVaLr+RldngC8vDKw==",
+      "requires": {
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-format-url": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/middleware-sdk-s3": {
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
@@ -12919,6 +13059,16 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
       "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
       "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.226.0.tgz",
+      "integrity": "sha512-IhuA8iuJL1urWqZZmVzW79mHnwFEEP6rMsSKgAfMmuzowhtgk9p/sT2OVPkXk0LeZL2Ghsnw1W2JfPIs8x1qVg==",
+      "requires": {
+        "@aws-sdk/querystring-builder": "3.226.0",
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.128.0",
+    "@aws-sdk/client-ec2": "^3.238.0",
     "@aws-sdk/client-s3": "^3.128.0",
     "@types/readline-sync": "^1.4.4",
     "readline-sync": "^1.4.10"


### PR DESCRIPTION
## Purpose

Updated destroyStack to start by deleting the stack's ENIs

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-22395

## Approach

Now at the beginning of the destroy process the tool will look up Security Groups in the stack being destroyed.  The list of security groups will then be used to find all attached ENIs.  Those ENIs will then me deleted to begin the process.
