### PR TITLE
fix(waiter):  Increase timeout to 2hr and wait in parallel

### DIFF
--- a/src/serverless-stage-destroyer.ts
+++ b/src/serverless-stage-destroyer.ts
@@ -70,9 +70,11 @@ export class ServerlessStageDestroyer {
 
     // Fifth, wait for stacks to be deleted.
     if (wait) {
+      let waiters = [];
       for (let i of stacksToDestroy || []) {
-        await this.ensureStackIsDeleted(region, `${i.StackName}`);
+        waiters.push(this.ensureStackIsDeleted(region, `${i.StackName}`));
       }
+      await Promise.all(waiters);
     }
   }
 
@@ -101,7 +103,7 @@ export class ServerlessStageDestroyer {
     await waitUntilStackDeleteComplete(
       {
         client: client,
-        maxWaitTime: 1500,
+        maxWaitTime: 7200,
       },
       {
         StackName: stack,


### PR DESCRIPTION
## Purpose

This changeset increases the waiter timeout to a max of 2hr (default custom resource timeout) and waits for stack deletion in parallel.

#### Linked Issues to Close

Closes #218 

## Approach

The timeout passed to cloudformation is now 7200s (2hr).  We put the calls to wait in an array and wait in parallel with Promise.all()

## Learning

None

## Assorted Notes/Considerations

None